### PR TITLE
fix: Support multi-line release notes

### DIFF
--- a/.github/workflows/reusable-publish-npm-package.yml
+++ b/.github/workflows/reusable-publish-npm-package.yml
@@ -100,7 +100,13 @@ jobs:
           mv CHANGELOG-new.md CHANGELOG.md
 
           RELEASE_NOTES="$( sed -n "/^# ${{ env.PACKAGE_VERSION }}/,/^#/p" CHANGELOG.md | grep -v "^#" | sed -e :a -e '/./,$!d;/^\n*$/{$d;N;};/\n$/ba' )"
-          echo "RELEASE_NOTES=$RELEASE_NOTES" >> "$GITHUB_ENV"
+
+          # The following is needed for multi-line env vars, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "RELEASE_NOTES<<$EOF" >> "$GITHUB_ENV"
+          echo "$RELEASE_NOTES" >> "$GITHUB_ENV"
+          echo "$EOF" >> "$GITHUB_ENV"
+
           echo "${{ env.RELEASE_NOTES }}"
 
       - name: Publish package to npm


### PR DESCRIPTION
Multi-line release notes broke the workflow due to multi-line env vars requiring special handling in GitHub Actions: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string

This commit implements the proposed solution.