### PR TITLE
fix(publish-npm-package): Fix issue in tagging of GH release with "Pre-release"

### DIFF
--- a/.github/workflows/reusable-publish-npm-package.yml
+++ b/.github/workflows/reusable-publish-npm-package.yml
@@ -149,8 +149,7 @@ jobs:
           else
             RELEASE_FLAG="--latest"
           fi
-          echo "RELEASE_FLAG=$RELEASE_FLAG" >> "$GITHUB_ENV"
-          gh release create "v${{ env.PACKAGE_VERSION }}" ${{ env.RELEASE_FLAG }} --title "v${{ env.PACKAGE_VERSION }}" --notes "${{ env.RELEASE_NOTES }}"
+          gh release create "v${{ env.PACKAGE_VERSION }}" $RELEASE_FLAG --title "v${{ env.PACKAGE_VERSION }}" --notes "${{ env.RELEASE_NOTES }}"
 
       - name: Create pull request
         env:

--- a/.github/workflows/reusable-publish-npm-package.yml
+++ b/.github/workflows/reusable-publish-npm-package.yml
@@ -150,7 +150,7 @@ jobs:
             RELEASE_FLAG="--latest"
           fi
           echo "RELEASE_FLAG=$RELEASE_FLAG" >> "$GITHUB_ENV"
-          gh release create "v${{ env.PACKAGE_VERSION }}" {{ env.RELEASE_FLAG }} --title "v${{ env.PACKAGE_VERSION }}" --notes "${{ env.RELEASE_NOTES }}"
+          gh release create "v${{ env.PACKAGE_VERSION }}" ${{ env.RELEASE_FLAG }} --title "v${{ env.PACKAGE_VERSION }}" --notes "${{ env.RELEASE_NOTES }}"
 
       - name: Create pull request
         env:


### PR DESCRIPTION
Fixes bug from https://github.com/mangrovedao/.github/pull/21

Tested successfully here: https://github.com/mangrovedao/release-automation-tests/actions/runs/7015735579/job/19085572333

NB: Once this is completed, the solution should be ported to the Foundry version of this script. PR for that here: https://github.com/mangrovedao/.github/pull/23