### PR TITLE
fix(publish-npm-package-with-foundry): Tag GH release with with "Pre-release" instead of "Latest" for prereleases

### DIFF
--- a/.github/workflows/reusable-publish-npm-package-with-foundry.yml
+++ b/.github/workflows/reusable-publish-npm-package-with-foundry.yml
@@ -147,7 +147,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.BOT_GH_PAT_TOKEN }}
         run: |
-          gh release create "v${{ env.PACKAGE_VERSION }}" --title "v${{ env.PACKAGE_VERSION }}" --notes "${{ env.RELEASE_NOTES }}"
+          if [ "${{ inputs.versionBumpStrategy }}" == "prerelease" ]; then
+            RELEASE_FLAG="--prerelease"
+          else
+            RELEASE_FLAG="--latest"
+          fi
+          gh release create "v${{ env.PACKAGE_VERSION }}" $RELEASE_FLAG --title "v${{ env.PACKAGE_VERSION }}" --notes "${{ env.RELEASE_NOTES }}"
 
       - name: Create pull request
         env:


### PR DESCRIPTION
Port of solution from https://github.com/mangrovedao/.github/pull/21 and https://github.com/mangrovedao/.github/pull/22

(these two npm publish workflows really should be consolidated...)